### PR TITLE
更改格式和部分翻译

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -135,7 +135,7 @@ because `guard` statement without `return`, `break` or `continue` produces a com
 
 <h4><details><summary>避免对 可选类型 强解包</summary>Avoid Using Force-Unwrapping of Optionals</details></h4>
 
-<details><summary>如果你有个 `FooType?` 或 `FooType!` 的 `foo`，尽量不要强行展开它以得到基本类型（`foo!`）。</summary>
+<details><summary>如果你有个 <code>FooType?</code> 或 <code>FooType!</code> 的 <code>foo</code>，尽量不要强行展开它以得到基本类型（<code>foo!</code>）。</summary>
 
 If you have an identifier `foo` of type `FooType?` or `FooType!`, don't force-unwrap it to get to the underlying value (`foo!`) if possible.
 </details>
@@ -160,31 +160,29 @@ Alternatively, you might want to use Swift's Optional Chaining in some of these 
 foo?.callSomethingIfFooIsNotNil()
 ```
 
-
-
-<details><summary>_理由：_ `if let` 绑定可选类型产生了更安全的代码，强行展开很可能导致运行时崩溃。</summary>
+<details><summary><i>理由：</i> <code>if let</code> 绑定可选类型产生了更安全的代码，强行展开很可能导致运行时崩溃。</summary>
 
 _Rationale:_ Explicit `if let`-binding of optionals results in safer code. Force unwrapping is more prone to lead to runtime crashes.
 </details>
 
 <h4><details><summary>避免毫无保留地展开可选类型</summary>Avoid Using Implicitly Unwrapped Optionals</details></h4>
 
-<details><summary>如果 foo 可能为 nil ，尽可能的用 `let foo: FooType?` 代替 `let foo: FooType!`（注意：一般情况下，`?`可以代替`!`）</summary>
+<details><summary>如果 foo 可能为 nil ，尽可能的用 <code>let foo: FooType?</code> 代替 <code>let foo: FooType!</code>（注意：一般情况下，<code>?</code>可以代替<code>!</code>）</summary>
 
 Where possible, use `let foo: FooType?` instead of `let foo: FooType!` if `foo` may be nil (Note that in general, `?` can be used instead of `!`).
 </details>
 
-<details><summary>_理由:_ 明确的可选类型产生了更安全的代码。无保留地展开可选类型也会挂。</summary>
+<details><summary><i>理由：</i> 明确的可选类型产生了更安全的代码。无保留地展开可选类型也会挂。</summary>
 
 _Rationale:_ Explicit optionals result in safer code. Implicitly unwrapped optionals have the potential of crashing at runtime.
 </details>
 
-<h4><details><summary>Prefer implicit getters on read-only properties and subscripts</summary>
+<h4><details><summary>对于只读属性和 <code>subscript</code>，选用隐式的 getters 方法</summary>
 
-对于只读属性的 `properties` 和 `subscripts`，选用隐式的 getters 方法
+Prefer implicit getters on read-only properties and subscripts
 </details></h4>
 
-<details><summary>如果可以，省略只读属性的 `properties` 和 `subscripts` 的 `get` 关键字</summary>
+<details><summary>如果可以，省略只读属性和 <code>subscript</code> 的 <code>get</code> 关键字</summary>
 
 When possible, omit the `get` keyword on read-only computed properties and
 read-only subscripts.</details>
@@ -217,7 +215,7 @@ subscript(index: Int) -> T {
 }
 ```
 
-<details><summary>_理由:_ 第一个版本的代码意图已经很清楚了，并且用了更少的代码</summary>
+<details><summary><i>理由：</i> 第一个版本的代码意图已经很清楚了，并且用了更少的代码</summary>
 
 _Rationale:_ The intent and meaning of the first version is clear, and results in less code.
 </details>
@@ -244,7 +242,7 @@ internal struct TheFez {
 }
 ```
 
-<details><summary>_理由:_ 顶级定义指定为 `internal`很少有恰当的，要明确的确保经过了仔细的判断。有了一个定义，重用同样的权限控制说明符就显得重复，所以默认的通常是合理的。</summary>
+<details><summary><i>理由：</i> 顶级定义指定为 <code>internal</code> 很少有恰当的，要明确的确保经过了仔细的判断。有了一个定义，重用同样的权限控制说明符就显得重复，所以默认的通常是合理的。</summary>
 
 _Rationale:_ It's rarely appropriate for top-level definitions to be specifically `internal`, and being explicit ensures that careful thought goes into that decision. Within a definition, reusing the same access control specifier is just duplicative, and the default is usually reasonable.
 </details>
@@ -270,7 +268,7 @@ func makeCoffee(type: CoffeeType) -> Coffee { ... }
 
 
 
-<details><summary>_理由:_ 类型区分号是对于 _identifier_ 来说的，所以要跟它连在一起。</summary>
+<details><summary><i>理由：</i> 类型区分号是对于标示符来说的，所以要跟它连在一起。</summary>
 
 _Rationale:_ The type specifier is saying something about the _identifier_ so
 it should be positioned with it.
@@ -285,7 +283,7 @@ Also, when specifying the type of a dictionary, always put the colon immediately
 let capitals: [Country: City] = [ Sweden: Stockholm ]
 ```
 
-<h4><details><summary>需要时才写上 `self`</summary>
+<h4><details><summary>需要时才写上 <code>self</code></summary>
 
 Only explicitly refer to `self` when required
 </details></h4>
@@ -293,7 +291,7 @@ Only explicitly refer to `self` when required
 
 
 
-<details><summary>当调用 `self` 的 `properties` 或 `methods` 时，`self` 用默认的隐式引用：</summary>
+<details><summary>当调用 <code>self</code> 的属性或方法时，<code>self</code> 用默认的隐式引用：</summary>
 
 When accessing properties or methods on `self`, leave the reference to `self` implicit by default:
 </details>
@@ -308,7 +306,7 @@ private class History {
 }
 ```
 
-<details><summary>必要的时候再加上`self`, 比如在闭包里，或者 参数名冲突了：</summary>
+<details><summary>必要的时候再加上 <code>self</code>, 比如在（逃逸）闭包里，或者 参数名冲突了：</summary>
 
 Only include the explicit keyword when required by the language—for example, in a closure, or when parameter names conflict:
 </details>
@@ -327,22 +325,22 @@ extension History {
 }
 ```
 
-<details><summary>_原因:_ 在闭包里用`self`更加凸显它的语义，并且避免了别处的冗长</summary>
+<details><summary><i>原因:</i> 在闭包里用 <code>self</code> 更加凸显它的语义，并且避免了别处的冗长</summary>
 
 _Rationale:_ This makes the capturing semantics of `self` stand out more in closures, and avoids verbosity elsewhere.
 </details>
 
-<h4><details><summary>首选 `structs` 而非 `classes`</summary>
+<h4><details><summary>首选 <code>struct</code> 而非 <code>class</code></summary>
 
 Prefer structs over classes
 </details></h4>
 
-<details><summary>除非你需要 `class` 才能提供的功能（比如 `identity` 或 `deinitializers`），不然就用 `struct`</summary>
+<details><summary>除非你需要 <code>class</code> 才能提供的功能（比如 identity 或 <code>deinit</code>ializers），不然就用 <code>struct</code></summary>
 
 Unless you require functionality that can only be provided by a class (like identity or deinitializers), implement a struct instead.
 </details>
 
-<details><summary>要注意到继承通常**不**是用 类 的好理由，因为 多态 可以通过 协议 实现，重用 可以通过 组合 实现。</summary>
+<details><summary>要注意到继承通常 <strong>不</strong> 是用 类 的好理由，因为 多态 可以通过 协议 实现，重用 可以通过 组合 实现。</summary>
 
 Note that inheritance is (by itself) usually _not_ a good reason to use classes, because polymorphism can be provided by protocols, and implementation reuse can be provided through composition.
 </details>
@@ -401,23 +399,23 @@ struct Car: Vehicle {
 }
 ```
 
-<details><summary>_理由:_ 值的类型更简单，容易辨别，并且通过`let`关键字可猜测行为。</summary>
+<details><summary><i>理由：</i> 值的类型更简单，容易辨别，并且通过 <code>let</code> 关键字可猜测行为。</summary>
 
 _Rationale:_ Value types are simpler, easier to reason about, and behave as expected with the `let` keyword.
 </details>
 
-<h4><details><summary>默认 `classes` 为 `final`</summary>
+<h4><details><summary>默认 <code>class</code> 为 <code>final</code></summary>
 
 Make classes `final` by default
 </details></h4>
 
-<details><summary>`Classes` 应该用`final`修饰，并且只有在继承的有效需求已被确定时候才能去使用子类。即便在这种情况（前面提到的使用继承的情况）下，根据同样的规则（`Classes` 应该用`final`修饰的规则），类中的定义（属性和方法等）也要尽可能的用 `final` 来修饰
+<details><summary><code>class</code> 应该用 <code>final</code> 修饰，并且只有在继承的有效需求已被确定时候才能去使用子类。即便在这种情况（前面提到的使用继承的情况）下，根据同样的规则（<code>class</code> 应该用 final</code> 修饰的规则），类中的定义（属性和方法等）也要尽可能的用 <code>final</code> 来修饰
 </summary>
 
 Classes should start as `final`, and only be changed to allow subclassing if a valid need for inheritance has been identified. Even in that case, as many definitions as possible _within_ the class should be `final` as well, following the same rules.
 </details>
 
-<details><summary>_理由:_ 组合通常比继承更合适，选择使用继承则很可能意味着在做出决定时需要更多的思考。</summary>
+<details><summary><i>理由：</i> 组合通常比继承更合适，选择使用继承则很可能意味着在做出决定时需要更多的思考。</summary>
 
 _Rationale:_ Composition is usually preferable to inheritance, and opting _in_ to inheritance hopefully means that more thought will be put into the decision.
 </details>
@@ -452,17 +450,17 @@ struct Composite<T> {
 }
 ```
 
-<details><summary>_理由:_ 省略多余的类型参数让意图更清晰，并且通过对比，让返回值为不同的类型参数的情况也清楚了很多。</summary>
+<details><summary><i>理由：</i> 省略多余的类型参数让意图更清晰，并且通过对比，让返回值为不同的类型参数的情况也清楚了很多。</summary>
 
 _Rationale:_ Omitting redundant type parameters clarifies the intent, and makes it obvious by contrast when the returned type takes different type parameters.
 </details>
 
-<h4><details><summary>操作定义符 两边留空格</summary>
+<h4><details><summary>定义操作符 两边留空格</summary>
 
 Use whitespace around operator definitions
 </details></h4>
 
-<details><summary>当定义操作定义符 时，两边留空格。不要酱紫：</summary>
+<details><summary>当定义操作符 时，两边留空格。不要酱紫：</summary>
 
 Use whitespace around operators when defining them. Instead of:
 </details>
@@ -479,7 +477,7 @@ func <| (lhs: Int, rhs: Int) -> Int
 func <|< <A>(lhs: A, rhs: A) -> A
 ```
 
-<details><summary>_理由：_ 操作符 由 标点字符组成，当立即连着 类型或者参数值，会让代码非常难读。加上空格分开他们就清晰了</summary>
+<details><summary><i>理由：</i> 操作符 由 标点字符组成，当立即连着 类型或者参数值，会让代码非常难读。加上空格分开他们就清晰了</summary>
 
 _Rationale:_ Operators consist of punctuation characters, which can make them difficult to read when immediately followed by the punctuation for a type or value parameter list. Adding whitespace separates the two more clearly.
 </details>

--- a/README_CN.md
+++ b/README_CN.md
@@ -40,7 +40,7 @@ then open a pull request. :zap:
 <h2><details><summary>留空白</summary>Whitespace</details></h2>
 
 <ul>
-<li><details><summary>用 tab，而非 空格</summary>Tabs, not spaces.</details></li>
+<li><details><summary>用 tab，而非 空格</summary>Tabs, not spaces.</details></li>
 <li><details><summary>文件结束时留一空行</summary>End files with a newline.</details></li>
 <li><details><summary>用足够的空行把代码分割成合理的块</summary>Make liberal use of vertical whitespace to divide code into logical chunks.</details></li>
 <li><details><summary>不要在一行结尾留下空白</summary>Don’t leave trailing whitespace.</details>
@@ -137,12 +137,12 @@ because `guard` statement without `return`, `break` or `continue` produces a com
 
 <h2><details><summary>避免对 可选类型 强解包</summary>Avoid Using Force-Unwrapping of Optionals</details></h2>
 
-<details><summary>如果你有个 <code>FooType?</code> 或 <code>FooType!</code> 的 <code>foo</code>，尽量不要强行展开它（<code>foo!</code>）以得到它的关联值。</summary>
+<details><summary>如果你有个 <code>FooType?</code> 或 <code>FooType!</code> 的 <code>foo</code>，尽量不要强行展开它（<code>foo!</code>）以得到它的关联值。</summary>
 
 If you have an identifier `foo` of type `FooType?` or `FooType!`, don't force-unwrap it to get to the underlying value (`foo!`) if possible.
 </details>
 
-<details><summary>取而代之的，推荐这样：</summary>Instead, prefer this:</details>
+<details><summary>取而代之的，推荐这样：</summary>Instead, prefer this:</details>
 
 ```swift
 if let foo = foo {
@@ -235,7 +235,7 @@ internal struct TheFez {}
 private func doTheThings(things: [Thing]) {}
 ```
 
-<details><summary>然而在这些函数/类型的内部，可以在合适的地方使用隐式权限控制：</summary>However, definitions within those can leave access control implicit, where appropriate:
+<details><summary>然而在这些函数/类型的内部，可以在合适的地方使用隐式权限控制：</summary>However, definitions within those can leave access control implicit, where appropriate:
 </details>
 
 ```swift

--- a/README_CN.md
+++ b/README_CN.md
@@ -425,5 +425,3 @@ func <|< <A>(lhs: A, rhs: A) -> A
 _Rationale:_ Operators consist of punctuation characters, which can make them difficult to read when immediately followed by the punctuation for a type or value parameter list. Adding whitespace separates the two more clearly.
 
 _理由：_ 操作符 由 标点字符组成，当立即连着 类型或者参数值，会让代码非常难读。加上空格分开他们就清晰了
-
-

--- a/README_CN.md
+++ b/README_CN.md
@@ -2,58 +2,51 @@
 如果看不懂，估计是我翻译的不好
 233333
 
-##[原版](https://github.com/github/swift-style-guide) 戳这里
+## [原版戳这里](https://github.com/github/swift-style-guide)
 
-哪里不对或者不准确的，若能指出（我把原文贴上来了，用来对照 2015-12-13）
+哪里不对或者不准确的，若能指出（我把原文贴上来了，点击左侧三角形就能展开用来对照 2015-12-13）
 感激不尽~~~
 
 如果没能及时更新，可能比较忙，或者比较懒 →_→
-可以 `Email` 或 翻译后，`pull request`
-
-
----
-
-#Swift 编码规范
-
-A guide to our Swift style and conventions.
-
-This is an attempt to encourage patterns that accomplish the following goals (in
-rough priority order):
-
- 1. Increased rigor, and decreased likelihood of programmer error
- 1. Increased clarity of intent
- 1. Reduced verbosity
- 1. Fewer debates about aesthetics
-
-If you have suggestions, please see our [contribution guidelines](CONTRIBUTING.md),
-then open a pull request. :zap:
-
-本文尝试做到以下几点 （大概的先后顺序）：
-
-1. 增进精确，减少程序员犯错的可能
-1. 明确意图
-1. 减少冗余
-1. 少量关于美的讨论
-
-如果你有什么建议，请看我们的 [贡献导引](CONTRIBUTING.md)，然后开个 `pull request`.  :zap:
+翻译后可以 email 或 `pull request`
 
 ----
 
-#### Whitespace
+<h1><details>
+<summary>Swift 编码规范</summary>
+A guide to our Swift style and conventions.
+</details></h1>
 
- * Tabs, not spaces.
- * End files with a newline.
- * Make liberal use of vertical whitespace to divide code into logical chunks.
- * Don’t leave trailing whitespace.
-   * Not even leading indentation on blank lines.
+<details><summary>本文尝试做到以下几点（大概的先后顺序）：</summary>
+This is an attempt to encourage patterns that accomplish the following goals (in
+rough priority order):
+</details>
 
-#### 留空白
+1. <details><summary>增进精确，减少程序员犯错的可能</summary>Increased rigor, and decreased likelihood of programmer error</details>
+1. <details><summary>明确意图</summary>Increased clarity of intent</details>
+1. <details><summary>减少冗余</summary>Reduced verbosity</details>
+1. <details><summary>减少关于美的争论</summary>Fewer debates about aesthetics</details>
 
- * 用 Tabs，而非 空格
- * 文件结束时留一空行
- * 用足够的空行把代码分割成合理的块
- * 不要在一行结尾留下空白
-   * 千万别在空行留下缩进
+<details>
+<summary>如果你有什么建议，请看我们的 <a href="./CONTRIBUTING.md">贡献导引</a>，然后开个 <code>pull request</code>. :zap:
+</summary>
+
+If you have suggestions, please see our [contribution guidelines](CONTRIBUTING.md),
+then open a pull request. :zap:
+</details>
+
+----
+
+<h4><details><summary>留空白</summary>Whitespace</details></h4>
+
+<ul>
+<li><details><summary>用 Tabs，而非 空格</summary>Tabs, not spaces.</details></li>
+<li><details><summary>文件结束时留一空行</summary>End files with a newline.</details></li>
+<li><details><summary>用足够的空行把代码分割成合理的块</summary>Make liberal use of vertical whitespace to divide code into logical chunks.</details></li>
+<li><details><summary>不要在一行结尾留下空白</summary>Don’t leave trailing whitespace.</details>
+	<ul><li><details><summary>千万别在空行留下缩进</summary>Not even leading indentation on blank lines.</details></li></ul>
+</li>
+</ul>
 
 #### Prefer `let`-bindings over `var`-bindings wherever possible
 #### 能用 `let` 尽量用 `let` 而不是 `var`

--- a/README_CN.md
+++ b/README_CN.md
@@ -88,16 +88,16 @@ When you have to meet certain criteria to continue execution, try to exit early.
 
 ```swift
 if n.isNumber {
-    // Use n here
+	// Use n here
 } else {
-    return
+	return
 }
 ```
 
 use this:
 ```swift
 guard n.isNumber else {
-    return
+	return
 }
 // Use n here
 ```
@@ -120,9 +120,9 @@ Instead, prefer this:
 
 ```swift
 if let foo = foo {
-    // Use unwrapped `foo` value in here
+	// Use unwrapped `foo` value in here
 } else {
-    // If appropriate, handle the case where the optional is nil
+	// If appropriate, handle the case where the optional is nil
 }
 ```
 
@@ -168,7 +168,7 @@ var myGreatProperty: Int {
 }
 
 subscript(index: Int) -> T {
-    return objects[index]
+	return objects[index]
 }
 ```
 
@@ -182,9 +182,9 @@ var myGreatProperty: Int {
 }
 
 subscript(index: Int) -> T {
-    get {
-        return objects[index]
-    }
+	get {
+		return objects[index]
+	}
 }
 ```
 
@@ -308,27 +308,27 @@ For example, this class hierarchy:
 
 ```swift
 class Vehicle {
-    let numberOfWheels: Int
+	let numberOfWheels: Int
 
-    init(numberOfWheels: Int) {
-        self.numberOfWheels = numberOfWheels
-    }
+	init(numberOfWheels: Int) {
+		self.numberOfWheels = numberOfWheels
+	}
 
-    func maximumTotalTirePressure(pressurePerWheel: Float) -> Float {
-        return pressurePerWheel * Float(numberOfWheels)
-    }
+	func maximumTotalTirePressure(pressurePerWheel: Float) -> Float {
+		return pressurePerWheel * Float(numberOfWheels)
+	}
 }
 
 class Bicycle: Vehicle {
-    init() {
-        super.init(numberOfWheels: 2)
-    }
+	init() {
+		super.init(numberOfWheels: 2)
+	}
 }
 
 class Car: Vehicle {
-    init() {
-        super.init(numberOfWheels: 4)
-    }
+	init() {
+		super.init(numberOfWheels: 4)
+	}
 }
 ```
 
@@ -338,19 +338,19 @@ could be refactored into these definitions:
 
 ```swift
 protocol Vehicle {
-    var numberOfWheels: Int { get }
+	var numberOfWheels: Int { get }
 }
 
 func maximumTotalTirePressure(vehicle: Vehicle, pressurePerWheel: Float) -> Float {
-    return pressurePerWheel * Float(vehicle.numberOfWheels)
+	return pressurePerWheel * Float(vehicle.numberOfWheels)
 }
 
 struct Bicycle: Vehicle {
-    let numberOfWheels = 2
+	let numberOfWheels = 2
 }
 
 struct Car: Vehicle {
-    let numberOfWheels = 4
+	let numberOfWheels = 4
 }
 ```
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,19 +1,19 @@
-郑重声明：  
-如果看不懂，估计是我翻译的不好  
-233333  
+郑重声明：
+如果看不懂，估计是我翻译的不好
+233333
 
-##[原版](https://github.com/github/swift-style-guide) 戳这里  
+##[原版](https://github.com/github/swift-style-guide) 戳这里
 
-哪里不对或者不准确的，若能指出（我把原文贴上来了，用来对照 2015-12-13）  
-感激不尽~~~  
+哪里不对或者不准确的，若能指出（我把原文贴上来了，用来对照 2015-12-13）
+感激不尽~~~
 
-如果没能及时更新，可能比较忙，或者比较懒 →_→    
+如果没能及时更新，可能比较忙，或者比较懒 →_→
 可以 `Email` 或 翻译后，`pull request`
 
 
 ---
 
-#Swift 编码规范 
+#Swift 编码规范
 
 A guide to our Swift style and conventions.
 
@@ -80,9 +80,9 @@ Accordingly, whenever you see a `var` identifier being used, assume that it will
 这样，无论何时你看到 `var`，就假设它会变，并问自己为啥。
 
 #### Return and break early
-#### 尽早地 `Return` 或者 `break` 
+#### 尽早地 `Return` 或者 `break`
 
-When you have to meet certain criteria to continue execution, try to exit early. So, instead of this:  
+When you have to meet certain criteria to continue execution, try to exit early. So, instead of this:
 
 当你遇到某些操作需要通过条件判断去执行，应当尽早地退出判断条件：你不应该用下面这种写法
 
@@ -106,7 +106,7 @@ You can also do it with `if` statement, but using `guard` is prefered, because `
 
 或者你也可以用 `if` 声明，但是我们推荐你使用 `guard`
 
-_理由：_ 你一但声明 `guard` 编译器会强制要求你和 `return`, `break` 或者 `continue` 一起搭配使用，否则会产生一个编译时的错误。 
+_理由：_ 你一但声明 `guard` 编译器会强制要求你和 `return`, `break` 或者 `continue` 一起搭配使用，否则会产生一个编译时的错误。
 
 
 #### Avoid Using Force-Unwrapping of Optionals

--- a/README_CN.md
+++ b/README_CN.md
@@ -2,8 +2,6 @@
 如果看不懂，估计是我翻译的不好
 233333
 
-## [原版戳这里](https://github.com/github/swift-style-guide)
-
 哪里不对或者不准确的，（我把原文贴上来了，点击左侧三角形就能展开用来对照 2015-12-13）
 若能指出，感激不尽~~~
 
@@ -37,7 +35,7 @@ then open a pull request. :zap:
 
 ----
 
-<h2><details><summary>留空白</summary>Whitespace</details></h2>
+<h3><details><summary>留空白</summary>Whitespace</details></h3>
 
 <ul>
 <li><details><summary>用 tab，而非 空格</summary>Tabs, not spaces.</details></li>
@@ -48,11 +46,11 @@ then open a pull request. :zap:
 </li>
 </ul>
 
-<h2><details>
+<h3><details>
 <summary>能用 <code>let</code> 尽量用 <code>let</code> 而不是 <code>var</code></summary>
 
 Prefer `let`-bindings over `var`-bindings wherever possible
-</details></h2>
+</details></h3>
 
 <details>
 <summary>
@@ -67,7 +65,7 @@ Use `let foo = …` over `var foo = …` wherever possible (and when in doubt). 
 <i>理由：</i> 这俩关键字 无论意图还是意义 都很清楚了，但是 <code>let</code> 可以产生安全清晰的代码。
 </summary>
 
-_Rationale:_ The intent and meaning of both keywords is clear, but *let-by-default* results in safer and clearer code.
+_Rationale:_ The intent and meaning of both keywords are clear, but *let-by-default* results in safer and clearer code.
 </details>
 
 <br />
@@ -95,10 +93,10 @@ It becomes easier to reason about code. Had you used `var` while still making th
 Accordingly, whenever you see a `var` identifier being used, assume that it will change and ask yourself why.
 </details>
 
-<h2><details><summary>
+<h3><details><summary>
 尽早地 <code>return</code> 或者 <code>break</code></summary>
 
-Return and break early</details></h2>
+Return and break early</details></h3>
 
 <details>
 <summary>当你遇到某些操作需要通过条件判断去执行，应当尽早地退出判断条件：你不应该用下面这种写法</summary>
@@ -135,7 +133,7 @@ You can also do it with `if` statement, but using `guard` is prefered
 because `guard` statement without `return`, `break` or `continue` produces a compile-time error, so exit is guaranteed.
 </details>
 
-<h2><details><summary>避免对 可选类型 强解包</summary>Avoid Using Force-Unwrapping of Optionals</details></h2>
+<h3><details><summary>避免对 可选类型 强解包</summary>Avoid Using Force-Unwrapping of Optionals</details></h3>
 
 <details><summary>如果你有个 <code>FooType?</code> 或 <code>FooType!</code> 的 <code>foo</code>，尽量不要强行展开它（<code>foo!</code>）以得到它的关联值。</summary>
 
@@ -167,7 +165,7 @@ foo?.callSomethingIfFooIsNotNil()
 _Rationale:_ Explicit `if let`-binding of optionals results in safer code. Force unwrapping is more prone to lead to runtime crashes.
 </details>
 
-<h2><details><summary>避免隐式解析的可选类型</summary>Avoid Using Implicitly Unwrapped Optionals</details></h2>
+<h3><details><summary>避免隐式解析的可选类型</summary>Avoid Using Implicitly Unwrapped Optionals</details></h3>
 
 <details><summary>如果 foo 可能为 <code>nil</code> ，尽可能的用 <code>let foo: FooType?</code> 代替 <code>let foo: FooType!</code>（注意：一般情况下，<code>?</code> 可以代替 <code>!</code>）</summary>
 
@@ -179,10 +177,10 @@ Where possible, use `let foo: FooType?` instead of `let foo: FooType!` if `foo` 
 _Rationale:_ Explicit optionals result in safer code. Implicitly unwrapped optionals have the potential of crashing at runtime.
 </details>
 
-<h2><details><summary>对于只读属性和 <code>subscript</code>，选用隐式的 getters 方法</summary>
+<h3><details><summary>对于只读属性和 <code>subscript</code>，选用隐式的 getters 方法</summary>
 
 Prefer implicit getters on read-only properties and subscripts
-</details></h2>
+</details></h3>
 
 <details><summary>如果可以，省略只读属性和 <code>subscript</code> 的 <code>get</code> 关键字</summary>
 
@@ -219,10 +217,10 @@ subscript(index: Int) -> T {
 
 <details><summary><i>理由：</i> 第一个版本的代码意图已经很清楚了，并且用了更少的代码</summary>
 
-_Rationale:_ The intent and meaning of the first version is clear, and results in less code.
+_Rationale:_ The intent and meaning of the first version are clear, and results in less code.
 </details>
 
-<h2><details><summary>对于顶级定义，永远明确的列出权限控制</summary>Always specify access control explicitly for top-level definitions</details></h2>
+<h3><details><summary>对于顶级定义，永远明确的列出权限控制</summary>Always specify access control explicitly for top-level definitions</details></h3>
 
 <details><summary>顶级函数，类型和变量，永远应该有着详尽的权限控制说明符</summary>
 
@@ -249,10 +247,10 @@ internal struct TheFez {
 _Rationale:_ It's rarely appropriate for top-level definitions to be specifically `internal`, and being explicit ensures that careful thought goes into that decision. Within a definition, reusing the same access control specifier is just duplicative, and the default is usually reasonable.
 </details>
 
-<h2><details><summary>当指定一个类型时，把 冒号和标识符 连在一起</summary>
+<h3><details><summary>当指定一个类型时，把 冒号和标识符 连在一起</summary>
 
 When specifying a type, always associate the colon with the identifier
-</details></h2>
+</details></h3>
 
 <details><summary>当指定标示符的类型时，冒号要紧跟着标示符，然后空一格再写类型</summary>
 
@@ -282,13 +280,13 @@ Also, when specifying the type of a dictionary, always put the colon immediately
 </details>
 
 ```swift
-let capitals: [Country: City] = [Sweden: Stockholm]
+let capitals: [Country: City] = [sweden: stockholm]
 ```
 
-<h2><details><summary>需要时才写上 <code>self</code></summary>
+<h3><details><summary>需要时才写上 <code>self</code></summary>
 
 Only explicitly refer to `self` when required
-</details></h2>
+</details></h3>
 
 <details><summary>当调用 <code>self</code> 的属性或方法时，默认隐式引用<code>self</code>：</summary>
 
@@ -329,10 +327,10 @@ extension History {
 _Rationale:_ This makes the capturing semantics of `self` stand out more in closures, and avoids verbosity elsewhere.
 </details>
 
-<h2><details><summary>首选 <code>struct</code> 而非 <code>class</code></summary>
+<h3><details><summary>首选 <code>struct</code> 而非 <code>class</code></summary>
 
 Prefer structs over classes
-</details></h2>
+</details></h3>
 
 <details><summary>除非你需要 <code>class</code> 才能提供的功能（比如 identity 或 <code>deinit</code>ializers），不然就用 <code>struct</code></summary>
 
@@ -403,10 +401,10 @@ struct Car: Vehicle {
 _Rationale:_ Value types are simpler, easier to reason about, and behave as expected with the `let` keyword.
 </details>
 
-<h2><details><summary>默认 <code>class</code> 为 <code>final</code></summary>
+<h3><details><summary>默认 <code>class</code> 为 <code>final</code></summary>
 
 Make classes `final` by default
-</details></h2>
+</details></h3>
 
 <details><summary><code>class</code> 应该用 <code>final</code> 修饰，并且只有在继承的有效需求已被确定时候才能去使用子类。即便在这种情况（前面提到的使用继承的情况）下，根据同样的规则（<code>class</code> 应该用 <code>final</code> 修饰的规则），类中的定义（属性和方法等）也要尽可能的用 <code>final</code> 来修饰
 </summary>
@@ -419,10 +417,10 @@ Classes should start as `final`, and only be changed to allow subclassing if a v
 _Rationale:_ Composition is usually preferable to inheritance, and opting _in_ to inheritance hopefully means that more thought will be put into the decision.
 </details>
 
-<h2><details><summary>能不写类型参数的就别写了</summary>
+<h3><details><summary>能不写类型参数的就别写了</summary>
 
 Omit type parameters where possible
-</details></h2>
+</details></h3>
 
 <details><summary>当对接收者来说一样时，参数化类型的方法可以省略接收者的类型参数。比如：</summary>
 
@@ -454,10 +452,10 @@ struct Composite<T> {
 _Rationale:_ Omitting redundant type parameters clarifies the intent, and makes it obvious by contrast when the returned type takes different type parameters.
 </details>
 
-<h2><details><summary>定义操作符 两边留空格</summary>
+<h3><details><summary>定义操作符 两边留空格</summary>
 
 Use whitespace around operator definitions
-</details></h2>
+</details></h3>
 
 <details><summary>当定义操作符时，两边留空格。不要酱紫：</summary>
 
@@ -480,3 +478,12 @@ func <|< <A>(lhs: A, rhs: A) -> A
 
 _Rationale:_ Operators consist of punctuation characters, which can make them difficult to read when immediately followed by the punctuation for a type or value parameter list. Adding whitespace separates the two more clearly.
 </details>
+
+### 其他语言
+
+* [English Version](https://github.com/github/swift-style-guide)
+* [日本語版](https://github.com/jarinosuke/swift-style-guide/blob/master/README_JP.md)
+* [한국어판](https://github.com/minsOne/swift-style-guide/blob/master/README_KR.md)
+* [Versión en Español](https://github.com/antoniosejas/swift-style-guide/blob/spanish/README-ES.md)
+* [Versão em Português do Brasil](https://github.com/fernandocastor/swift-style-guide/blob/master/README-PTBR.md)
+* [فارسی](https://github.com/mohpor/swift-style-guide/blob/Persian/README-FA.md)

--- a/README_CN.md
+++ b/README_CN.md
@@ -93,12 +93,16 @@ It becomes easier to reason about code. Had you used `var` while still making th
 Accordingly, whenever you see a `var` identifier being used, assume that it will change and ask yourself why.
 </details>
 
-#### Return and break early
-#### 尽早地 `Return` 或者 `break`
+<h4><details><summary>
+尽早地 <code>return</code> 或者 <code>break</code></summary>
+
+Return and break early</details></h4>
+
+<details>
+<summary>当你遇到某些操作需要通过条件判断去执行，应当尽早地退出判断条件：你不应该用下面这种写法</summary>
 
 When you have to meet certain criteria to continue execution, try to exit early. So, instead of this:
-
-当你遇到某些操作需要通过条件判断去执行，应当尽早地退出判断条件：你不应该用下面这种写法
+</details>
 
 ```swift
 if n.isNumber {
@@ -109,6 +113,7 @@ if n.isNumber {
 ```
 
 use this:
+
 ```swift
 guard n.isNumber else {
 	return
@@ -116,19 +121,24 @@ guard n.isNumber else {
 // Use n here
 ```
 
-You can also do it with `if` statement, but using `guard` is prefered, because `guard` statement without `return`, `break` or `continue` produces a compile-time error, so exit is guaranteed.
+<details>
+<summary>或者你也可以用 <code>if</code> 声明，但是我们推荐你使用 <code>guard</code></summary>
 
-或者你也可以用 `if` 声明，但是我们推荐你使用 `guard`
+You can also do it with `if` statement, but using `guard` is prefered
+</details>
 
-_理由：_ 你一但声明 `guard` 编译器会强制要求你和 `return`, `break` 或者 `continue` 一起搭配使用，否则会产生一个编译时的错误。
+<details>
+<summary><i>理由：</i> 你一但声明 <code>guard</code> 编译器会强制要求你和 <code>return</code>, <code>break</code> 或者 <code>continue</code> 一起搭配使用，否则会产生一个编译时的错误。</summary>
 
+because `guard` statement without `return`, `break` or `continue` produces a compile-time error, so exit is guaranteed.
+</details>
 
-#### Avoid Using Force-Unwrapping of Optionals
-#### 避免对 可选类型 强解包
+<h4><details><summary>避免对 可选类型 强解包</summary>Avoid Using Force-Unwrapping of Optionals</details></h4>
+
+<details><summary>如果你有个 `FooType?` 或 `FooType!` 的 `foo`，尽量不要强行展开它以得到基本类型（`foo!`）。</summary>
 
 If you have an identifier `foo` of type `FooType?` or `FooType!`, don't force-unwrap it to get to the underlying value (`foo!`) if possible.
-
-如果你有个 `FooType?` 或 `FooType!` 的 `foo`，尽量不要强行展开它以得到基本类型（`foo!`）。
+</details>
 
 Instead, prefer this:
 
@@ -140,39 +150,44 @@ if let foo = foo {
 }
 ```
 
-Alternatively, you might want to use Swift's Optional Chaining in some of these cases, such as:
+<details><summary>或者使用可选链，比如：</summary>
 
-或者使用可选链，比如：
+Alternatively, you might want to use Swift's Optional Chaining in some of these cases, such as:
+</details>
 
 ```swift
 // Call the function if `foo` is not nil. If `foo` is nil, ignore we ever tried to make the call
 foo?.callSomethingIfFooIsNotNil()
 ```
 
+
+
+<details><summary>_理由：_ `if let` 绑定可选类型产生了更安全的代码，强行展开很可能导致运行时崩溃。</summary>
+
 _Rationale:_ Explicit `if let`-binding of optionals results in safer code. Force unwrapping is more prone to lead to runtime crashes.
+</details>
 
-_理由：_ `if let` 绑定可选类型产生了更安全的代码，强行展开很可能导致运行时崩溃。
+<h4><details><summary>避免毫无保留地展开可选类型</summary>Avoid Using Implicitly Unwrapped Optionals</details></h4>
 
-
-#### Avoid Using Implicitly Unwrapped Optionals
-#### 避免毫无保留地展开可选类型
+<details><summary>如果 foo 可能为 nil ，尽可能的用 `let foo: FooType?` 代替 `let foo: FooType!`（注意：一般情况下，`?`可以代替`!`）</summary>
 
 Where possible, use `let foo: FooType?` instead of `let foo: FooType!` if `foo` may be nil (Note that in general, `?` can be used instead of `!`).
+</details>
+
+<details><summary>_理由:_ 明确的可选类型产生了更安全的代码。无保留地展开可选类型也会挂。</summary>
 
 _Rationale:_ Explicit optionals result in safer code. Implicitly unwrapped optionals have the potential of crashing at runtime.
+</details>
 
-如果 foo 可能为 nil ，尽可能的用 `let foo: FooType?` 代替 `let foo: FooType!`（注意：一般情况下，`?`可以代替`!`）
+<h4><details><summary>Prefer implicit getters on read-only properties and subscripts</summary>
 
-_理由:_ 明确的可选类型产生了更安全的代码。无保留地展开可选类型也会挂。
+对于只读属性的 `properties` 和 `subscripts`，选用隐式的 getters 方法
+</details></h4>
 
-
-#### Prefer implicit getters on read-only properties and subscripts
-#### 对于只读属性的 `properties` 和 `subscripts`，选用隐式的 getters 方法
+<details><summary>如果可以，省略只读属性的 `properties` 和 `subscripts` 的 `get` 关键字</summary>
 
 When possible, omit the `get` keyword on read-only computed properties and
-read-only subscripts.
-
-如果可以，省略只读属性的 `properties` 和 `subscripts` 的 `get` 关键字
+read-only subscripts.</details>
 
 So, write these:
 
@@ -202,17 +217,17 @@ subscript(index: Int) -> T {
 }
 ```
 
+<details><summary>_理由:_ 第一个版本的代码意图已经很清楚了，并且用了更少的代码</summary>
+
 _Rationale:_ The intent and meaning of the first version is clear, and results in less code.
+</details>
 
-_理由:_ 第一个版本的代码意图已经很清楚了，并且用了更少的代码
+<h4><details><summary>对于顶级定义，永远明确的列出权限控制</summary>Always specify access control explicitly for top-level definitions</details></h4>
 
-#### Always specify access control explicitly for top-level definitions
-#### 对于顶级定义，永远明确的列出权限控制
+<details><summary>顶级函数，类型和变量，永远应该有着详尽的权限控制说明符</summary>
 
 Top-level functions, types, and variables should always have explicit access control specifiers:
-
-顶级函数，类型和变量，永远应该有着详尽的权限控制说明符
-
+</details>
 
 ```swift
 public var whoopsGlobalState: Int
@@ -220,9 +235,8 @@ internal struct TheFez {}
 private func doTheThings(things: [Thing]) {}
 ```
 
-However, definitions within those can leave access control implicit, where appropriate:
-
-当然，这样也是恰当的，因为用了隐式权限控制
+<details><summary>当然，这样也是恰当的，因为用了隐式权限控制</summary>However, definitions within those can leave access control implicit, where appropriate:
+</details>
 
 ```swift
 internal struct TheFez {
@@ -230,17 +244,21 @@ internal struct TheFez {
 }
 ```
 
+<details><summary>_理由:_ 顶级定义指定为 `internal`很少有恰当的，要明确的确保经过了仔细的判断。有了一个定义，重用同样的权限控制说明符就显得重复，所以默认的通常是合理的。</summary>
+
 _Rationale:_ It's rarely appropriate for top-level definitions to be specifically `internal`, and being explicit ensures that careful thought goes into that decision. Within a definition, reusing the same access control specifier is just duplicative, and the default is usually reasonable.
+</details>
 
-_理由:_ 顶级定义指定为 `internal`很少有恰当的，要明确的确保经过了仔细的判断。有了一个定义，重用同样的权限控制说明符就显得重复，所以默认的通常是合理的。
+<h4><details><summary>当指定一个类型时，把 冒号和标识符 连在一起</summary>
 
-#### When specifying a type, always associate the colon with the identifier
-#### 当指定一个类型时，把 冒号和标识符 连在一起
+When specifying a type, always associate the colon with the identifier
+</details></h4>
+
+<details><summary>当指定标示符的类型时，冒号要紧跟着标示符，然后空一格再写类型</summary>
 
 When specifying the type of an identifier, always put the colon immediately
 after the identifier, followed by a space and then the type name.
-
-当指定标示符的类型时，冒号要紧跟着标示符，然后空一格再写类型
+</details>
 
 ```swift
 class SmallBatchSustainableFairtrade: Coffee { ... }
@@ -250,26 +268,35 @@ let timeToCoffee: NSTimeInterval = 2
 func makeCoffee(type: CoffeeType) -> Coffee { ... }
 ```
 
+
+
+<details><summary>_理由:_ 类型区分号是对于 _identifier_ 来说的，所以要跟它连在一起。</summary>
+
 _Rationale:_ The type specifier is saying something about the _identifier_ so
 it should be positioned with it.
+</details>
 
-_理由:_ 类型区分号是对于 _identifier_ 来说的，所以要跟它连在一起。
+<details><summary>此外，指定字典类型时，键类型后紧跟着冒号，接着加一个空格，之后才是值类型。</summary>
 
 Also, when specifying the type of a dictionary, always put the colon immediately after the key type, followed by a space and then the value type.
-
-此外，指定字典类型时，键类型后紧跟着冒号，接着加一个空格，之后才是值类型。
+</details>
 
 ```swift
 let capitals: [Country: City] = [ Sweden: Stockholm ]
 ```
 
+<h4><details><summary>需要时才写上 `self`</summary>
 
-#### Only explicitly refer to `self` when required
-#### 需要时才写上 `self`
+Only explicitly refer to `self` when required
+</details></h4>
+
+
+
+
+<details><summary>当调用 `self` 的 `properties` 或 `methods` 时，`self` 用默认的隐式引用：</summary>
 
 When accessing properties or methods on `self`, leave the reference to `self` implicit by default:
-
-当调用 `self` 的 `properties` 或 `methods` 时，`self` 用默认的隐式引用：
+</details>
 
 ```swift
 private class History {
@@ -281,9 +308,10 @@ private class History {
 }
 ```
 
-Only include the explicit keyword when required by the language—for example, in a closure, or when parameter names conflict:
+<details><summary>必要的时候再加上`self`, 比如在闭包里，或者 参数名冲突了：</summary>
 
-必要的时候再加上`self`, 比如在闭包里，或者 参数名冲突了：
+Only include the explicit keyword when required by the language—for example, in a closure, or when parameter names conflict:
+</details>
 
 ```swift
 extension History {
@@ -299,26 +327,30 @@ extension History {
 }
 ```
 
+<details><summary>_原因:_ 在闭包里用`self`更加凸显它的语义，并且避免了别处的冗长</summary>
+
 _Rationale:_ This makes the capturing semantics of `self` stand out more in closures, and avoids verbosity elsewhere.
+</details>
 
-_原因:_ 在闭包里用`self`更加凸显它的语义，并且避免了别处的冗长
+<h4><details><summary>首选 `structs` 而非 `classes`</summary>
 
+Prefer structs over classes
+</details></h4>
 
-#### Prefer structs over classes
-#### 首选 `structs` 而非 `classes`
+<details><summary>除非你需要 `class` 才能提供的功能（比如 `identity` 或 `deinitializers`），不然就用 `struct`</summary>
 
 Unless you require functionality that can only be provided by a class (like identity or deinitializers), implement a struct instead.
+</details>
+
+<details><summary>要注意到继承通常**不**是用 类 的好理由，因为 多态 可以通过 协议 实现，重用 可以通过 组合 实现。</summary>
 
 Note that inheritance is (by itself) usually _not_ a good reason to use classes, because polymorphism can be provided by protocols, and implementation reuse can be provided through composition.
+</details>
+
+<details><summary>比如，这个类的分级</summary>
 
 For example, this class hierarchy:
-
-
-除非你需要 `class` 才能提供的功能（比如 `identity` 或 `deinitializers`），不然就用 `struct`
-
-要注意到继承通常**不**是用 类 的好理由，因为 多态 可以通过 协议 实现，重用 可以通过 组合 实现。
-
-比如，这个类的分级
+</details>
 
 ```swift
 class Vehicle {
@@ -346,9 +378,10 @@ class Car: Vehicle {
 }
 ```
 
-could be refactored into these definitions:
+<details><summary>可以重构成酱紫：</summary>
 
-可以重构成酱紫：
+could be refactored into these definitions:
+</details>
 
 ```swift
 protocol Vehicle {
@@ -368,29 +401,36 @@ struct Car: Vehicle {
 }
 ```
 
+<details><summary>_理由:_ 值的类型更简单，容易辨别，并且通过`let`关键字可猜测行为。</summary>
+
 _Rationale:_ Value types are simpler, easier to reason about, and behave as expected with the `let` keyword.
+</details>
 
-_理由:_ 值的类型更简单，容易辨别，并且通过`let`关键字可猜测行为。
+<h4><details><summary>默认 `classes` 为 `final`</summary>
 
+Make classes `final` by default
+</details></h4>
 
-
-#### Make classes `final` by default
-#### 默认 `classes` 为 `final`
+<details><summary>`Classes` 应该用`final`修饰，并且只有在继承的有效需求已被确定时候才能去使用子类。即便在这种情况（前面提到的使用继承的情况）下，根据同样的规则（`Classes` 应该用`final`修饰的规则），类中的定义（属性和方法等）也要尽可能的用 `final` 来修饰
+</summary>
 
 Classes should start as `final`, and only be changed to allow subclassing if a valid need for inheritance has been identified. Even in that case, as many definitions as possible _within_ the class should be `final` as well, following the same rules.
+</details>
+
+<details><summary>_理由:_ 组合通常比继承更合适，选择使用继承则很可能意味着在做出决定时需要更多的思考。</summary>
 
 _Rationale:_ Composition is usually preferable to inheritance, and opting _in_ to inheritance hopefully means that more thought will be put into the decision.
+</details>
 
-`Classes` 应该用`final`修饰，并且只有在继承的有效需求已被确定时候才能去使用子类。即便在这种情况（前面提到的使用继承的情况）下，根据同样的规则（`Classes` 应该用`final`修饰的规则），类中的定义（属性和方法等）也要尽可能的用 `final` 来修饰
+<h4><details><summary>能不写类型参数的就别写了</summary>
 
-_理由:_ 组合通常比继承更合适，选择使用继承则很可能意味着在做出决定时需要更多的思考。
+Omit type parameters where possible
+</details></h4>
 
-#### Omit type parameters where possible
-#### 能不写类型参数的就别写了
+<details><summary>参数化类型的方法可以省略接收者的类型参数，当他们对接收者来说一样时。比如：</summary>
 
 Methods of parameterized types can omit type parameters on the receiving type when they’re identical to the receiver’s. For example:
-
-参数化类型的方法可以省略接收者的类型参数，当他们对接收者来说一样时。比如：
+</details>
 
 ```swift
 struct Composite<T> {
@@ -412,17 +452,20 @@ struct Composite<T> {
 }
 ```
 
+<details><summary>_理由:_ 省略多余的类型参数让意图更清晰，并且通过对比，让返回值为不同的类型参数的情况也清楚了很多。</summary>
+
 _Rationale:_ Omitting redundant type parameters clarifies the intent, and makes it obvious by contrast when the returned type takes different type parameters.
+</details>
 
-_理由:_ 省略多余的类型参数让意图更清晰，并且通过对比，让返回值为不同的类型参数的情况也清楚了很多。
+<h4><details><summary>操作定义符 两边留空格</summary>
 
+Use whitespace around operator definitions
+</details></h4>
 
-#### Use whitespace around operator definitions
-#### 操作定义符 两边留空格
+<details><summary>当定义操作定义符 时，两边留空格。不要酱紫：</summary>
 
 Use whitespace around operators when defining them. Instead of:
-
-当定义操作定义符 时，两边留空格。不要酱紫：
+</details>
 
 ```swift
 func <|(lhs: Int, rhs: Int) -> Int
@@ -436,6 +479,7 @@ func <| (lhs: Int, rhs: Int) -> Int
 func <|< <A>(lhs: A, rhs: A) -> A
 ```
 
-_Rationale:_ Operators consist of punctuation characters, which can make them difficult to read when immediately followed by the punctuation for a type or value parameter list. Adding whitespace separates the two more clearly.
+<details><summary>_理由：_ 操作符 由 标点字符组成，当立即连着 类型或者参数值，会让代码非常难读。加上空格分开他们就清晰了</summary>
 
-_理由：_ 操作符 由 标点字符组成，当立即连着 类型或者参数值，会让代码非常难读。加上空格分开他们就清晰了
+_Rationale:_ Operators consist of punctuation characters, which can make them difficult to read when immediately followed by the punctuation for a type or value parameter list. Adding whitespace separates the two more clearly.
+</details>

--- a/README_CN.md
+++ b/README_CN.md
@@ -114,7 +114,7 @@ if n.isNumber {
 }
 ```
 
-use this:
+<details><summary>用这个：</summary>use this:</details>
 
 ```swift
 guard n.isNumber else {
@@ -142,7 +142,7 @@ because `guard` statement without `return`, `break` or `continue` produces a com
 If you have an identifier `foo` of type `FooType?` or `FooType!`, don't force-unwrap it to get to the underlying value (`foo!`) if possible.
 </details>
 
-Instead, prefer this:
+<details><summary>取而代之的，推荐这样：</summary>Instead, prefer this:</details>
 
 ```swift
 if let foo = foo {
@@ -189,7 +189,7 @@ Prefer implicit getters on read-only properties and subscripts
 When possible, omit the `get` keyword on read-only computed properties and
 read-only subscripts.</details>
 
-So, write these:
+<details><summary>所以应该这样写：</summary>So, write these:</details>
 
 ```swift
 var myGreatProperty: Int {
@@ -201,7 +201,7 @@ subscript(index: Int) -> T {
 }
 ```
 
-… not these:
+<details><summary>……而不是：</summary>… not these:</details>
 
 ```swift
 var myGreatProperty: Int {
@@ -268,8 +268,6 @@ let timeToCoffee: NSTimeInterval = 2
 func makeCoffee(type: CoffeeType) -> Coffee { ... }
 ```
 
-
-
 <details><summary><i>理由：</i> 类型区分号是对于标示符来说的，所以要跟它连在一起。</summary>
 
 _Rationale:_ The type specifier is saying something about the _identifier_ so
@@ -291,9 +289,6 @@ let capitals: [Country: City] = [Sweden: Stockholm]
 
 Only explicitly refer to `self` when required
 </details></h2>
-
-
-
 
 <details><summary>当调用 <code>self</code> 的属性或方法时，默认隐式引用<code>self</code>：</summary>
 
@@ -443,7 +438,7 @@ struct Composite<T> {
 }
 ```
 
-could be rendered as:
+<details><summary>可以改成这样：</summary>could be rendered as:</details>
 
 ```swift
 struct Composite<T> {
@@ -464,7 +459,7 @@ _Rationale:_ Omitting redundant type parameters clarifies the intent, and makes 
 Use whitespace around operator definitions
 </details></h2>
 
-<details><summary>当定义操作符 时，两边留空格。不要酱紫：</summary>
+<details><summary>当定义操作符时，两边留空格。不要酱紫：</summary>
 
 Use whitespace around operators when defining them. Instead of:
 </details>
@@ -474,14 +469,14 @@ func <|(lhs: Int, rhs: Int) -> Int
 func <|<<A>(lhs: A, rhs: A) -> A
 ```
 
-write:
+<details><summary>应该写：</summary>write:</details>
 
 ```swift
 func <| (lhs: Int, rhs: Int) -> Int
 func <|< <A>(lhs: A, rhs: A) -> A
 ```
 
-<details><summary><i>理由：</i> 操作符 由 标点字符组成，当立即连着 类型或者参数值，会让代码非常难读。加上空格分开他们就清晰了</summary>
+<details><summary><i>理由：</i> 操作符 由标点字符组成，当立即连着类型或者参数值，会让代码非常难读。加上空格分开他们就清晰了</summary>
 
 _Rationale:_ Operators consist of punctuation characters, which can make them difficult to read when immediately followed by the punctuation for a type or value parameter list. Adding whitespace separates the two more clearly.
 </details>

--- a/README_CN.md
+++ b/README_CN.md
@@ -48,29 +48,50 @@ then open a pull request. :zap:
 </li>
 </ul>
 
-#### Prefer `let`-bindings over `var`-bindings wherever possible
-#### 能用 `let` 尽量用 `let` 而不是 `var`
+<h4><details>
+<summary>能用 <code>let</code> 尽量用 <code>let</code> 而不是 <code>var</code></summary>
+
+Prefer `let`-bindings over `var`-bindings wherever possible
+</details></h4>
+
+<details>
+<summary>
+尽可能的用 <code>let foo = ...</code> 而不是 <code>var foo = ...</code> （并且包括你疑惑的时候）。万不得已的时候，再用 <code>var</code> （就是说：你 <i>知道</i> 这个值会改变，比如：有 <code>weak</code> 修饰的存储变量）。
+</summary>
 
 Use `let foo = …` over `var foo = …` wherever possible (and when in doubt). Only use `var` if you absolutely have to (i.e. you *know* that the value might change, e.g. when using the `weak` storage modifier).
+</details>
+
+<details>
+<summary>
+<i>理由：</i> 这俩关键字 无论意图还是意义 都很清楚了，但是 <code>let</code> 可以产生安全清晰的代码。
+</summary>
 
 _Rationale:_ The intent and meaning of both keywords is clear, but *let-by-default* results in safer and clearer code.
+</details>
 
-尽可能的用 `let foo = ...` 而不是 `var foo = ...` （并且包括你疑惑的时候）。万不得已的时候，再用 `var` （就是说：你 *知道* 这个值会改变，比如：有 `weak` 修饰的存储变量）。
-
-_理由：_ 这俩关键字 无论意图还是意义 都很清楚了，但是 *let* 可以产生安全清晰的代码。
+<details>
+<summary>
+<code>let</code>-有保障 并且它的值的永远不会变对程序猿也是个 <i>清晰的标记</i>，对于它的用法，之后的代码可以做个强而有力的推断。</summary>
 
 A `let`-binding guarantees and *clearly signals to the programmer* that its value will never change. Subsequent code can thus make stronger assumptions about its usage.
+</details>
+
+<details>
+<summary>
+猜测代码更容易了。不然一旦你用了 <code>var</code>，还要去推测值会不会变，这时候你就不得不人肉去检查。
+</summary>
 
 It becomes easier to reason about code. Had you used `var` while still making the assumption that the value never changed, you would have to manually check that.
+</details>
+
+<details>
+<summary>
+这样，无论何时你看到 <code>var</code>，就假设它会变，并问自己为啥。
+</summary>
 
 Accordingly, whenever you see a `var` identifier being used, assume that it will change and ask yourself why.
-
-
-`let`-有保障 并且它的值的永远不会变对程序猿也是个 *清晰的标记*，对于它的用法，之后的代码可以做个强而有力的推断。
-
-猜测代码更容易了。不然一旦你用了 `var`，还要去推测值会不会变，这时候你就不得不人肉去检查。
-
-这样，无论何时你看到 `var`，就假设它会变，并问自己为啥。
+</details>
 
 #### Return and break early
 #### 尽早地 `Return` 或者 `break`

--- a/README_CN.md
+++ b/README_CN.md
@@ -4,8 +4,8 @@
 
 ## [原版戳这里](https://github.com/github/swift-style-guide)
 
-哪里不对或者不准确的，若能指出（我把原文贴上来了，点击左侧三角形就能展开用来对照 2015-12-13）
-感激不尽~~~
+哪里不对或者不准确的，（我把原文贴上来了，点击左侧三角形就能展开用来对照 2015-12-13）
+若能指出，感激不尽~~~
 
 如果没能及时更新，可能比较忙，或者比较懒 →_→
 翻译后可以 email 或 `pull request`
@@ -17,7 +17,7 @@
 A guide to our Swift style and conventions.
 </details></h1>
 
-<details><summary>本文尝试做到以下几点（大概的先后顺序）：</summary>
+<details><summary>按大概的先后顺序，本文尝试做到以下几点：</summary>
 This is an attempt to encourage patterns that accomplish the following goals (in
 rough priority order):
 </details>
@@ -37,10 +37,10 @@ then open a pull request. :zap:
 
 ----
 
-<h4><details><summary>留空白</summary>Whitespace</details></h4>
+<h2><details><summary>留空白</summary>Whitespace</details></h2>
 
 <ul>
-<li><details><summary>用 Tabs，而非 空格</summary>Tabs, not spaces.</details></li>
+<li><details><summary>用 tab，而非 空格</summary>Tabs, not spaces.</details></li>
 <li><details><summary>文件结束时留一空行</summary>End files with a newline.</details></li>
 <li><details><summary>用足够的空行把代码分割成合理的块</summary>Make liberal use of vertical whitespace to divide code into logical chunks.</details></li>
 <li><details><summary>不要在一行结尾留下空白</summary>Don’t leave trailing whitespace.</details>
@@ -48,11 +48,11 @@ then open a pull request. :zap:
 </li>
 </ul>
 
-<h4><details>
+<h2><details>
 <summary>能用 <code>let</code> 尽量用 <code>let</code> 而不是 <code>var</code></summary>
 
 Prefer `let`-bindings over `var`-bindings wherever possible
-</details></h4>
+</details></h2>
 
 <details>
 <summary>
@@ -70,16 +70,18 @@ Use `let foo = …` over `var foo = …` wherever possible (and when in doubt). 
 _Rationale:_ The intent and meaning of both keywords is clear, but *let-by-default* results in safer and clearer code.
 </details>
 
+<br />
+
 <details>
 <summary>
-<code>let</code>-有保障 并且它的值的永远不会变对程序猿也是个 <i>清晰的标记</i>，对于它的用法，之后的代码可以做个强而有力的推断。</summary>
+<code>let</code> 保障它的值的永远不会变，对程序猿也是个 <i>清晰的标记</i>。因此对于它的用法，之后的代码可以做个强而有力的推断。</summary>
 
 A `let`-binding guarantees and *clearly signals to the programmer* that its value will never change. Subsequent code can thus make stronger assumptions about its usage.
 </details>
 
 <details>
 <summary>
-猜测代码更容易了。不然一旦你用了 <code>var</code>，还要去推测值会不会变，这时候你就不得不人肉去检查。
+理解代码也更容易了。不然一旦你用了 <code>var</code>，还要去推测值会不会变，这时候你就不得不人肉去检查。
 </summary>
 
 It becomes easier to reason about code. Had you used `var` while still making the assumption that the value never changed, you would have to manually check that.
@@ -87,16 +89,16 @@ It becomes easier to reason about code. Had you used `var` while still making th
 
 <details>
 <summary>
-这样，无论何时你看到 <code>var</code>，就假设它会变，并问自己为啥。
+相应地，无论何时你看到 <code>var</code>，就假设它会变，并问自己为啥。
 </summary>
 
 Accordingly, whenever you see a `var` identifier being used, assume that it will change and ask yourself why.
 </details>
 
-<h4><details><summary>
+<h2><details><summary>
 尽早地 <code>return</code> 或者 <code>break</code></summary>
 
-Return and break early</details></h4>
+Return and break early</details></h2>
 
 <details>
 <summary>当你遇到某些操作需要通过条件判断去执行，应当尽早地退出判断条件：你不应该用下面这种写法</summary>
@@ -133,9 +135,9 @@ You can also do it with `if` statement, but using `guard` is prefered
 because `guard` statement without `return`, `break` or `continue` produces a compile-time error, so exit is guaranteed.
 </details>
 
-<h4><details><summary>避免对 可选类型 强解包</summary>Avoid Using Force-Unwrapping of Optionals</details></h4>
+<h2><details><summary>避免对 可选类型 强解包</summary>Avoid Using Force-Unwrapping of Optionals</details></h2>
 
-<details><summary>如果你有个 <code>FooType?</code> 或 <code>FooType!</code> 的 <code>foo</code>，尽量不要强行展开它以得到基本类型（<code>foo!</code>）。</summary>
+<details><summary>如果你有个 <code>FooType?</code> 或 <code>FooType!</code> 的 <code>foo</code>，尽量不要强行展开它（<code>foo!</code>）以得到它的关联值。</summary>
 
 If you have an identifier `foo` of type `FooType?` or `FooType!`, don't force-unwrap it to get to the underlying value (`foo!`) if possible.
 </details>
@@ -165,22 +167,22 @@ foo?.callSomethingIfFooIsNotNil()
 _Rationale:_ Explicit `if let`-binding of optionals results in safer code. Force unwrapping is more prone to lead to runtime crashes.
 </details>
 
-<h4><details><summary>避免毫无保留地展开可选类型</summary>Avoid Using Implicitly Unwrapped Optionals</details></h4>
+<h2><details><summary>避免隐式解析的可选类型</summary>Avoid Using Implicitly Unwrapped Optionals</details></h2>
 
-<details><summary>如果 foo 可能为 nil ，尽可能的用 <code>let foo: FooType?</code> 代替 <code>let foo: FooType!</code>（注意：一般情况下，<code>?</code>可以代替<code>!</code>）</summary>
+<details><summary>如果 foo 可能为 <code>nil</code> ，尽可能的用 <code>let foo: FooType?</code> 代替 <code>let foo: FooType!</code>（注意：一般情况下，<code>?</code> 可以代替 <code>!</code>）</summary>
 
 Where possible, use `let foo: FooType?` instead of `let foo: FooType!` if `foo` may be nil (Note that in general, `?` can be used instead of `!`).
 </details>
 
-<details><summary><i>理由：</i> 明确的可选类型产生了更安全的代码。无保留地展开可选类型也会挂。</summary>
+<details><summary><i>理由：</i> 明确的可选类型产生了更安全的代码。隐式解析的可选类型也可能会挂。</summary>
 
 _Rationale:_ Explicit optionals result in safer code. Implicitly unwrapped optionals have the potential of crashing at runtime.
 </details>
 
-<h4><details><summary>对于只读属性和 <code>subscript</code>，选用隐式的 getters 方法</summary>
+<h2><details><summary>对于只读属性和 <code>subscript</code>，选用隐式的 getters 方法</summary>
 
 Prefer implicit getters on read-only properties and subscripts
-</details></h4>
+</details></h2>
 
 <details><summary>如果可以，省略只读属性和 <code>subscript</code> 的 <code>get</code> 关键字</summary>
 
@@ -220,7 +222,7 @@ subscript(index: Int) -> T {
 _Rationale:_ The intent and meaning of the first version is clear, and results in less code.
 </details>
 
-<h4><details><summary>对于顶级定义，永远明确的列出权限控制</summary>Always specify access control explicitly for top-level definitions</details></h4>
+<h2><details><summary>对于顶级定义，永远明确的列出权限控制</summary>Always specify access control explicitly for top-level definitions</details></h2>
 
 <details><summary>顶级函数，类型和变量，永远应该有着详尽的权限控制说明符</summary>
 
@@ -233,7 +235,7 @@ internal struct TheFez {}
 private func doTheThings(things: [Thing]) {}
 ```
 
-<details><summary>当然，这样也是恰当的，因为用了隐式权限控制</summary>However, definitions within those can leave access control implicit, where appropriate:
+<details><summary>然而在这些函数/类型的内部，可以在合适的地方使用隐式权限控制：</summary>However, definitions within those can leave access control implicit, where appropriate:
 </details>
 
 ```swift
@@ -242,15 +244,15 @@ internal struct TheFez {
 }
 ```
 
-<details><summary><i>理由：</i> 顶级定义指定为 <code>internal</code> 很少有恰当的，要明确的确保经过了仔细的判断。有了一个定义，重用同样的权限控制说明符就显得重复，所以默认的通常是合理的。</summary>
+<details><summary><i>理由：</i> 顶级定义指定为 <code>internal</code> 很少有恰当的，要明确的确保经过了仔细的判断。在定义的内部重用同样的权限控制说明符就显得重复，而且默认的通常是合理的。</summary>
 
 _Rationale:_ It's rarely appropriate for top-level definitions to be specifically `internal`, and being explicit ensures that careful thought goes into that decision. Within a definition, reusing the same access control specifier is just duplicative, and the default is usually reasonable.
 </details>
 
-<h4><details><summary>当指定一个类型时，把 冒号和标识符 连在一起</summary>
+<h2><details><summary>当指定一个类型时，把 冒号和标识符 连在一起</summary>
 
 When specifying a type, always associate the colon with the identifier
-</details></h4>
+</details></h2>
 
 <details><summary>当指定标示符的类型时，冒号要紧跟着标示符，然后空一格再写类型</summary>
 
@@ -274,24 +276,26 @@ _Rationale:_ The type specifier is saying something about the _identifier_ so
 it should be positioned with it.
 </details>
 
+<br />
+
 <details><summary>此外，指定字典类型时，键类型后紧跟着冒号，接着加一个空格，之后才是值类型。</summary>
 
 Also, when specifying the type of a dictionary, always put the colon immediately after the key type, followed by a space and then the value type.
 </details>
 
 ```swift
-let capitals: [Country: City] = [ Sweden: Stockholm ]
+let capitals: [Country: City] = [Sweden: Stockholm]
 ```
 
-<h4><details><summary>需要时才写上 <code>self</code></summary>
+<h2><details><summary>需要时才写上 <code>self</code></summary>
 
 Only explicitly refer to `self` when required
-</details></h4>
+</details></h2>
 
 
 
 
-<details><summary>当调用 <code>self</code> 的属性或方法时，<code>self</code> 用默认的隐式引用：</summary>
+<details><summary>当调用 <code>self</code> 的属性或方法时，默认隐式引用<code>self</code>：</summary>
 
 When accessing properties or methods on `self`, leave the reference to `self` implicit by default:
 </details>
@@ -325,15 +329,15 @@ extension History {
 }
 ```
 
-<details><summary><i>原因:</i> 在闭包里用 <code>self</code> 更加凸显它的语义，并且避免了别处的冗长</summary>
+<details><summary><i>原因:</i> 在闭包里用 <code>self</code> 更加凸显它捕获 <code>self</code> 的语义，别处避免了冗长</summary>
 
 _Rationale:_ This makes the capturing semantics of `self` stand out more in closures, and avoids verbosity elsewhere.
 </details>
 
-<h4><details><summary>首选 <code>struct</code> 而非 <code>class</code></summary>
+<h2><details><summary>首选 <code>struct</code> 而非 <code>class</code></summary>
 
 Prefer structs over classes
-</details></h4>
+</details></h2>
 
 <details><summary>除非你需要 <code>class</code> 才能提供的功能（比如 identity 或 <code>deinit</code>ializers），不然就用 <code>struct</code></summary>
 
@@ -399,17 +403,17 @@ struct Car: Vehicle {
 }
 ```
 
-<details><summary><i>理由：</i> 值的类型更简单，容易辨别，并且通过 <code>let</code> 关键字可猜测行为。</summary>
+<details><summary><i>理由：</i> 值类型更简单，容易分析，并且 <code>let</code> 关键字的行为符合预期。</summary>
 
 _Rationale:_ Value types are simpler, easier to reason about, and behave as expected with the `let` keyword.
 </details>
 
-<h4><details><summary>默认 <code>class</code> 为 <code>final</code></summary>
+<h2><details><summary>默认 <code>class</code> 为 <code>final</code></summary>
 
 Make classes `final` by default
-</details></h4>
+</details></h2>
 
-<details><summary><code>class</code> 应该用 <code>final</code> 修饰，并且只有在继承的有效需求已被确定时候才能去使用子类。即便在这种情况（前面提到的使用继承的情况）下，根据同样的规则（<code>class</code> 应该用 final</code> 修饰的规则），类中的定义（属性和方法等）也要尽可能的用 <code>final</code> 来修饰
+<details><summary><code>class</code> 应该用 <code>final</code> 修饰，并且只有在继承的有效需求已被确定时候才能去使用子类。即便在这种情况（前面提到的使用继承的情况）下，根据同样的规则（<code>class</code> 应该用 <code>final</code> 修饰的规则），类中的定义（属性和方法等）也要尽可能的用 <code>final</code> 来修饰
 </summary>
 
 Classes should start as `final`, and only be changed to allow subclassing if a valid need for inheritance has been identified. Even in that case, as many definitions as possible _within_ the class should be `final` as well, following the same rules.
@@ -420,12 +424,12 @@ Classes should start as `final`, and only be changed to allow subclassing if a v
 _Rationale:_ Composition is usually preferable to inheritance, and opting _in_ to inheritance hopefully means that more thought will be put into the decision.
 </details>
 
-<h4><details><summary>能不写类型参数的就别写了</summary>
+<h2><details><summary>能不写类型参数的就别写了</summary>
 
 Omit type parameters where possible
-</details></h4>
+</details></h2>
 
-<details><summary>参数化类型的方法可以省略接收者的类型参数，当他们对接收者来说一样时。比如：</summary>
+<details><summary>当对接收者来说一样时，参数化类型的方法可以省略接收者的类型参数。比如：</summary>
 
 Methods of parameterized types can omit type parameters on the receiving type when they’re identical to the receiver’s. For example:
 </details>
@@ -455,10 +459,10 @@ struct Composite<T> {
 _Rationale:_ Omitting redundant type parameters clarifies the intent, and makes it obvious by contrast when the returned type takes different type parameters.
 </details>
 
-<h4><details><summary>定义操作符 两边留空格</summary>
+<h2><details><summary>定义操作符 两边留空格</summary>
 
 Use whitespace around operator definitions
-</details></h4>
+</details></h2>
 
 <details><summary>当定义操作符 时，两边留空格。不要酱紫：</summary>
 


### PR DESCRIPTION
- <details><summary>使用 details > summary 收起英文原文</summary>个人感觉至少比中英混杂排版要稍微好些，不过肯定是有利有弊</details>
- 纠正了部分翻译，重新组织了不是很通顺的部分
- 补充完了无关紧要但是未翻译或是未更新的部分

### 题外话

1. diff 不是很直观，推荐看渲染之后的 markdown
2. 估计是因为他们自己也不用这个的，GitHub 本身已经没有了维护的念头。